### PR TITLE
Simplify formatting of tz2t

### DIFF
--- a/bin/o2t
+++ b/bin/o2t
@@ -69,4 +69,9 @@ function processInput
     done
 }
 
-processInput
+if [ -t 1 ]; then
+    srcDir="$(dirname "$0")"
+    processInput | "$srcDir"/tz2o reformat
+else
+    processInput
+fi

--- a/bin/tz2t
+++ b/bin/tz2t
@@ -4,7 +4,7 @@
 srcDir="$(dirname "$0")"
 
 if [ "$1" != '--help' ]; then
-    "$srcDir"/tz2o "$@" | "$srcDir"/o2t | "$srcDir"/tz2o reformat
+    "$srcDir"/tz2o "$@" | "$srcDir"/o2t
 else
     echo "List offset, timezone, description and time from a provided timezone or offset."
     "$srcDir"/tz2o --help --noHeader | sed 's/tz2o/tz2t/g'


### PR DESCRIPTION
Previously this was done by tz2t sending the output back to tz2o to be reformatted. Now tz2o does this itself.

This simplifies assumptions for up-coming features because they don't need to worry about whether formatting might be applied after them.